### PR TITLE
WordPress利用時の$コンフリクト回避

### DIFF
--- a/jquery.jpostal.js
+++ b/jquery.jpostal.js
@@ -12,6 +12,8 @@
  * Requirements
  * jquery.js
  */
+ (function($) {
+ 
 var Jpostal = {};
 
 Jpostal.Database = function () {
@@ -803,3 +805,5 @@ window.jQuery_jpostal_callback = function (i_data) {
     };
 
 }));
+
+})( jQuery );


### PR DESCRIPTION
WordPressでjquery.jpostal.jsを利用しようとするとjQueryの$がコンフリクトするため、ローカルでカプセル化した後に利用しているためです。